### PR TITLE
fix: naming of migration to flyway format

### DIFF
--- a/src/main/resources/database/migration/V1_1__create_user_table.sql
+++ b/src/main/resources/database/migration/V1_1__create_user_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS users.users
+(
+    cpf varchar(11) UNIQUE NOT NULL,
+    name varchar(256) NOT NULL,
+    email varchar(128) NOT NULL,
+    registration varchar(10) UNIQUE NOT NULL,
+    image varchar(256) NOT NULL,
+    password varchar(128) NOT NULL,
+    role smallint NOT NULL DEFAULT 0,   -- 0 is user, 1 is admin
+    enabled boolean NOT NULL DEFAULT true,
+    CONSTRAINT users_pkey PRIMARY  KEY (cpf)
+);

--- a/src/main/resources/database/migration/V4_1__alter_table_time_intervals_change_time_type.sql
+++ b/src/main/resources/database/migration/V4_1__alter_table_time_intervals_change_time_type.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ufpel_data.time_intervals
+ALTER COLUMN start_time TYPE TIME,
+ALTER COLUMN end_time TYPE TIME;


### PR DESCRIPTION
Alterei o nome da migration de v4_1... para V4_1... para o flyway não gerar um erro
Criei uma migration 1_1 para criar a tabela de usuários