### PR TITLE
Hotfix/history data

### DIFF
--- a/src/main/java/com/ecoufpel/ecoufpelapp/domains/sensor/ClassroomDataAggregation.java
+++ b/src/main/java/com/ecoufpel/ecoufpelapp/domains/sensor/ClassroomDataAggregation.java
@@ -1,0 +1,25 @@
+package com.ecoufpel.ecoufpelapp.domains.sensor;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "classroom_data_aggregation", schema = "sensor_data")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ClassroomDataAggregation {
+    @Id
+    private String classroomId;
+    private Integer avgConsumption;
+    private Integer minConsumption;
+    private Integer maxConsumption;
+    private Integer stdConsumption;
+    private Timestamp aggregationDate;
+}

--- a/src/main/java/com/ecoufpel/ecoufpelapp/domains/websocket/CourseChangeDTO.java
+++ b/src/main/java/com/ecoufpel/ecoufpelapp/domains/websocket/CourseChangeDTO.java
@@ -1,4 +1,4 @@
-package com.ecoufpel.ecoufpelapp.domains.ufpel_data;
+package com.ecoufpel.ecoufpelapp.domains.websocket;
 
 import org.springframework.web.socket.TextMessage;
 

--- a/src/main/java/com/ecoufpel/ecoufpelapp/domains/websocket/ExpectedConsumptionMessageDTO.java
+++ b/src/main/java/com/ecoufpel/ecoufpelapp/domains/websocket/ExpectedConsumptionMessageDTO.java
@@ -1,4 +1,4 @@
-package com.ecoufpel.ecoufpelapp.domains.ufpel_data;
+package com.ecoufpel.ecoufpelapp.domains.websocket;
 
 import org.springframework.web.socket.TextMessage;
 

--- a/src/main/java/com/ecoufpel/ecoufpelapp/repositories/CoursesRepository.java
+++ b/src/main/java/com/ecoufpel/ecoufpelapp/repositories/CoursesRepository.java
@@ -1,7 +1,6 @@
 package com.ecoufpel.ecoufpelapp.repositories;
 
-import com.ecoufpel.ecoufpelapp.domains.ufpel_data.Classrooms;
-import com.ecoufpel.ecoufpelapp.domains.ufpel_data.CourseChangeDTO;
+import com.ecoufpel.ecoufpelapp.domains.websocket.CourseChangeDTO;
 import com.ecoufpel.ecoufpelapp.domains.ufpel_data.Courses;
 import com.ecoufpel.ecoufpelapp.domains.ufpel_data.TimeIntervals;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,7 +22,7 @@ public interface CoursesRepository extends JpaRepository<Courses, String> {
     public Optional<TimeIntervals> findTimeIntervalsByUserCpf(String userCpf);
 
 @Query("""
-    SELECT new com.ecoufpel.ecoufpelapp.domains.ufpel_data.CourseChangeDTO(
+    SELECT new com.ecoufpel.ecoufpelapp.domains.websocket.CourseChangeDTO(
             cour.title AS currentActivity, class.id AS classroomId, cour.id AS courseId, ?1 AS userCpf)
     FROM Classrooms as class
     JOIN CourseInRoom AS cir ON cir.id.classroomId = class.id

--- a/src/main/java/com/ecoufpel/ecoufpelapp/repositories/DataConsumptionRepository.java
+++ b/src/main/java/com/ecoufpel/ecoufpelapp/repositories/DataConsumptionRepository.java
@@ -17,10 +17,10 @@ public interface DataConsumptionRepository extends JpaRepository<DataConsumption
     Optional<List<DataConsumption>> findById_DateTimeBetween(Timestamp startTimestamp, Timestamp endTimestamp);
     @Query("""
         SELECT new com.ecoufpel.ecoufpelapp.domains.sensor.DailyAverageConsumption(
-            MIN(c.id.dateTime) AS date, AVG(c.consumption) AS avgConsumption)
-        FROM DataConsumption c
-        WHERE c.id.classroomId = :classroomId AND c.id.dateTime BETWEEN :start AND :end
-        GROUP BY DATE(c.id.dateTime)
+            MIN(c.aggregationDate) AS date, AVG(c.avgConsumption) AS avgConsumption)
+        FROM ClassroomDataAggregation c
+        WHERE c.classroomId = :classroomId AND c.aggregationDate BETWEEN :start AND :end
+        GROUP BY DATE(c.aggregationDate)
     """)
     List<DailyAverageConsumption> getDailyAverageConsumption(
             @Param("classroomId") String classroomId,

--- a/src/main/java/com/ecoufpel/ecoufpelapp/services/GetActivityChangeService.java
+++ b/src/main/java/com/ecoufpel/ecoufpelapp/services/GetActivityChangeService.java
@@ -1,6 +1,6 @@
 package com.ecoufpel.ecoufpelapp.services;
 
-import com.ecoufpel.ecoufpelapp.domains.ufpel_data.CourseChangeDTO;
+import com.ecoufpel.ecoufpelapp.domains.websocket.CourseChangeDTO;
 import com.ecoufpel.ecoufpelapp.repositories.CoursesRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.util.Pair;

--- a/src/main/java/com/ecoufpel/ecoufpelapp/services/GetExpectedConsumptionService.java
+++ b/src/main/java/com/ecoufpel/ecoufpelapp/services/GetExpectedConsumptionService.java
@@ -1,7 +1,7 @@
 package com.ecoufpel.ecoufpelapp.services;
 
 import com.ecoufpel.ecoufpelapp.domains.sensor.DataConsumption;
-import com.ecoufpel.ecoufpelapp.domains.ufpel_data.ExpectedConsumptionMessageDTO;
+import com.ecoufpel.ecoufpelapp.domains.websocket.ExpectedConsumptionMessageDTO;
 import com.ecoufpel.ecoufpelapp.repositories.DataConsumptionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.util.Pair;


### PR DESCRIPTION
Alterei a tabela de consulta dos dados históricos da tabela DataConsumption para a tabela ClassroomDataAggregation. Isto faz com que as queries de histórico sejam muito mais eficientes, porque a tabela tem bem menos registros.
Ainda troquei o localização de algumas mensagens do websocket para a pasta domains.websocket, pra ficar mais organizado